### PR TITLE
Fixes handling of special chars in Javadocs

### DIFF
--- a/i18n-core/pom.xml
+++ b/i18n-core/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>i18n-framework</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-core</artifactId>
   <name>Wren Security I18N Core</name>

--- a/i18n-jul/pom.xml
+++ b/i18n-jul/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>i18n-framework</artifactId>
     <groupId>org.forgerock.commons</groupId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-jul</artifactId>
   <name>Wren Security I18N Java Logging Support</name>

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>i18n-framework</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/AbstractGenerateMessagesMojo.java
+++ b/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/AbstractGenerateMessagesMojo.java
@@ -11,7 +11,8 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
- *      Copyright 2011-2013 ForgeRock AS
+ *      Copyright 2011-2013 ForgeRock AS.
+ *      Portions Copyright 2017 Wren Security.
  */
 package org.forgerock.i18n.maven;
 
@@ -334,6 +335,7 @@ abstract class AbstractGenerateMessagesMojo extends AbstractMojo {
         String getComment() {
             final StringBuilder sb = new StringBuilder();
             sb.append(indent(1)).append("/**").append(EOL);
+            sb.append(indent(1)).append(" * ").append("{@code").append(EOL);
 
             // Unwrapped so that you can search through the descriptor
             // file for a message and not have to worry about line breaks
@@ -343,6 +345,8 @@ abstract class AbstractGenerateMessagesMojo extends AbstractMojo {
             for (final String s : sa) {
                 sb.append(indent(1)).append(" * ").append(s).append(EOL);
             }
+
+            sb.append(indent(1)).append(" * ").append("}").append(EOL);
             sb.append(indent(1)).append(" */").append(EOL);
             return sb.toString();
         }

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <artifactId>i18n-framework</artifactId>
     <groupId>org.forgerock.commons</groupId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
   </parent>
   <artifactId>i18n-slf4j</artifactId>
   <name>Wren Security I18N SLF4J Support</name>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
   </parent>
   <groupId>org.forgerock.commons</groupId>
   <artifactId>i18n-framework</artifactId>
-  <version>1.4.2</version>
+  <version>1.4.3-SNAPSHOT</version>
   <name>Wren Security I18N Framework</name>
   <description>A fork of ForgeRock's common framework for embedding localizable messages in
     applications</description>


### PR DESCRIPTION
depends on merging https://github.com/WrenSecurity/wrensec-i18n-framework/pull/4 first

Without this fix, if a localizable message contains tags or other special characters, the generated Javadoc will cause generation to fail.