### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-i18n-framework)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-i18n-framework"
+export BINTRAY_PACKAGE="wrensec-i18n-framework"
+export JFROG_PACKAGE="org/forgerock/commons/i18n-framework"

--- a/i18n-core/pom.xml
+++ b/i18n-core/pom.xml
@@ -74,17 +74,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/i18n-core/pom.xml
+++ b/i18n-core/pom.xml
@@ -20,7 +20,8 @@
  !
  ! CDDL HEADER END
  !
- !      Copyright 2011 ForgeRock AS
+ !      Copyright 2011 ForgeRock AS.
+ !      Portions Copyright 2017 Wren Security.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -31,7 +32,7 @@
     <version>1.4.2</version>
   </parent>
   <artifactId>i18n-core</artifactId>
-  <name>ForgeRock I18N Core</name>
+  <name>Wren Security I18N Core</name>
   <description>
     This module provides core Java APIs for embedding and using
     localizable messages in applications.

--- a/i18n-jul/pom.xml
+++ b/i18n-jul/pom.xml
@@ -20,7 +20,8 @@
  !
  ! CDDL HEADER END
  !
- !      Copyright 2011 ForgeRock AS
+ !      Copyright 2011 ForgeRock AS.
+ !      Portions Copyright 2017 Wren Security.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -31,7 +32,7 @@
     <version>1.4.2</version>
   </parent>
   <artifactId>i18n-jul</artifactId>
-  <name>ForgeRock I18N Java Logging Support</name>
+  <name>Wren Security I18N Java Logging Support</name>
   <description>This module provides an interface for efficiently writing localized messages out to a java.util.logging.Logger</description>
   <packaging>bundle</packaging>
   <dependencies>

--- a/i18n-jul/pom.xml
+++ b/i18n-jul/pom.xml
@@ -73,17 +73,6 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -56,4 +56,55 @@
       </plugin>
     </plugins>
   </reporting>
+  <!-- may be temporary -->
+  <!-- FIXME: This is a workaround for non-standard Javadoc tags that FR is using to indicate
+       information about Maven-related properties in the Mojos. -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <tags>
+            <tag>
+              <name>Checkstyle</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+            <tag>
+              <name>goal</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+            <tag>
+              <name>parameter</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+            <tag>
+              <name>phase</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+            <tag>
+              <name>readonly</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+            <tag>
+              <name>required</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+            <tag>
+              <name>threadSafe</name>
+              <!-- The value X makes javadoc ignoring the tag -->
+              <placement>X</placement>
+            </tag>
+          </tags>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <!-- /may be temporary -->
 </project>

--- a/i18n-maven-plugin/pom.xml
+++ b/i18n-maven-plugin/pom.xml
@@ -20,7 +20,8 @@
  !
  ! CDDL HEADER END
  !
- !      Copyright 2011 ForgeRock AS
+ !      Copyright 2011 ForgeRock AS.
+ !      Portions Copyright 2017 Wren Security.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -32,7 +33,7 @@
   </parent>
   <artifactId>i18n-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>ForgeRock I18N Maven Plugin</name>
+  <name>Wren Security I18N Maven Plugin</name>
   <description>A Maven plugin which generates I18N messages from property files</description>
   <dependencies>
     <dependency>

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -20,7 +20,8 @@
  !
  ! CDDL HEADER END
  !
- !      Copyright 2011 ForgeRock AS
+ !      Copyright 2011 ForgeRock AS.
+ !      Portions Copyright 2017 Wren Security.
  !    
  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -31,7 +32,7 @@
     <version>1.4.2</version>
   </parent>
   <artifactId>i18n-slf4j</artifactId>
-  <name>ForgeRock I18N SLF4J Support</name>
+  <name>Wren Security I18N SLF4J Support</name>
   <description>This module provides an interface for efficiently writing localized messages out to a SLF4J Logger</description>
   <packaging>bundle</packaging>
   <dependencies>

--- a/i18n-slf4j/pom.xml
+++ b/i18n-slf4j/pom.xml
@@ -87,17 +87,6 @@
           <link>http://www.slf4j.org/apidocs</link>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,17 @@
     <connection>scm:git:git://github.com/WrenSecurity/wrensec-i18n-framework.git</connection>
     <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-i18n-framework.git</developerConnection>
   </scm>
-
   <distributionManagement>
     <snapshotRepository>
-      <id>bintray-wrensecurity-releases</id>
+      <id>wrensecurity-snapshots</id>
       <name>Wren Security Snapshot Repository</name>
-      <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-i18n-framework/;publish=1</url>
+      <url>${forgerockDistMgmtSnapshotsUrl}</url>
     </snapshotRepository>
 
     <repository>
-      <id>bintray-wrensecurity-snapshots</id>
+      <id>wrensecurity-releases</id>
       <name>Wren Security Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}/wrensec-i18n-framework/;publish=1</url>
+      <url>${forgerockDistMgmtReleasesUrl}</url>
     </repository>
   </distributionManagement>
   <modules>
@@ -116,10 +115,11 @@
     </dependency>
   </dependencies>
   <repositories>
+    <!-- Needed to retrieve parent POM -->
     <repository>
-      <id>bintray-wrensecurity-releases</id>
+      <id>wrensecurity-releases</id>
       <name>Wren Security Release Repository</name>
-      <url>http://dl.bintray.com/wrensecurity/releases</url>
+      <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
       <snapshots>
         <enabled>false</enabled>
@@ -127,20 +127,6 @@
 
       <releases>
         <enabled>true</enabled>
-      </releases>
-    </repository>
-
-    <repository>
-      <id>bintray-wrensecurity-snapshots</id>
-      <name>Wren Security Snapshot Repository</name>
-      <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-
-      <releases>
-        <enabled>false</enabled>
       </releases>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
   !
   ! CDDL HEADER END
   !
-  !      Copyright 2011 ForgeRock AS
+  !      Copyright 2011 ForgeRock AS.
+  !      Portions Copyright 2017 Wren Security.
   !    
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -35,50 +36,33 @@
   <groupId>org.forgerock.commons</groupId>
   <artifactId>i18n-framework</artifactId>
   <version>1.4.2</version>
-  <name>ForgeRock I18N Framework</name>
-  <description>A common framework for embedding localizable messages in applications</description>
-  <url>http://commons.forgerock.org/i18n-framework</url>
+  <name>Wren Security I18N Framework</name>
+  <description>A fork of ForgeRock's common framework for embedding localizable messages in
+    applications</description>
+  <url>http://wrensecurity.org</url>
   <packaging>pom</packaging>
   <issueManagement>
-    <system>Jira</system>
-    <url>https://bugster.forgerock.org/jira/browse/CINTFR</url>
+    <system>GitHub Issues</system>
+    <url>https://github.com/WrenSecurity/wrensec-i18n-framework/issues</url>
   </issueManagement>
-  <mailingLists>
-    <mailingList>
-      <!-- TODO: need mailing list -->
-      <name>I18N Mailing List</name>
-      <archive>http://lists.forgerock.org/pipermail/opendj/</archive>
-      <subscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</subscribe>
-      <unsubscribe>https://lists.forgerock.org/mailman/listinfo/opendj/</unsubscribe>
-      <post>opendj@forgerock.org</post>
-    </mailingList>
-  </mailingLists>
   <scm>
-    <url>https://svn.forgerock.org/commons/i18n-framework/tags/1.4.2</url>
-    <connection>scm:svn:https://svn.forgerock.org/commons/i18n-framework/tags/1.4.2</connection>
-    <developerConnection>scm:svn:https://svn.forgerock.org/commons/i18n-framework/tags/1.4.2</developerConnection>
+    <url>https://github.com/WrenSecurity/wrensec-i18n-framework</url>
+    <connection>scm:git:git://github.com/WrenSecurity/wrensec-i18n-framework.git</connection>
+    <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-i18n-framework.git</developerConnection>
   </scm>
-  <ciManagement>
-    <system>jenkins</system>
-    <url>http://builds.forgerock.org/job/Commons%20-%20I18N%20Framework/</url>
-    <notifiers>
-      <notifier>
-        <type>mail</type>
-        <sendOnError>true</sendOnError>
-        <sendOnFailure>true</sendOnFailure>
-        <sendOnSuccess>false</sendOnSuccess>
-        <sendOnWarning>false</sendOnWarning>
-        <!-- TODO: need mailing list -->
-        <address>opendj-dev@forgerock.org</address>
-      </notifier>
-    </notifiers>
-  </ciManagement>
+
   <distributionManagement>
-    <site>
-      <id>forgerock.org</id>
-      <name>OpenDJ Community</name>
-      <url>scp://forgerock.org/var/www/vhosts/commons.forgerock.org/httpdocs/i18n-framework</url>
-    </site>
+    <snapshotRepository>
+      <id>bintray-wrensecurity-releases</id>
+      <name>Wren Security Snapshot Repository</name>
+      <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-i18n-framework/;publish=1</url>
+    </snapshotRepository>
+
+    <repository>
+      <id>bintray-wrensecurity-snapshots</id>
+      <name>Wren Security Release Repository</name>
+      <url>${forgerockDistMgmtReleasesUrl}/wrensec-i18n-framework/;publish=1</url>
+    </repository>
   </distributionManagement>
   <modules>
     <module>i18n-maven-plugin</module>
@@ -133,17 +117,28 @@
   </dependencies>
   <repositories>
     <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>http://maven.forgerock.org/repo/releases</url>
+      <id>bintray-wrensecurity-releases</id>
+      <name>Wren Security Release Repository</name>
+      <url>http://dl.bintray.com/wrensecurity/releases</url>
+
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
+
+      <releases>
+        <enabled>true</enabled>
+      </releases>
     </repository>
+
     <repository>
-      <id>forgerock-snapshots-repository</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>http://maven.forgerock.org/repo/snapshots</url>
+      <id>bintray-wrensecurity-snapshots</id>
+      <name>Wren Security Snapshot Repository</name>
+      <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+
       <releases>
         <enabled>false</enabled>
       </releases>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- corrects issues blocking JavaDoc generation in JDK 8+ (unsupported tags).
- updates branding to call this Wren Security I18N instead of ForgeRock I18N.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.